### PR TITLE
Assert request in a collection returns 200 status

### DIFF
--- a/AccountCheck.postman_collection.json
+++ b/AccountCheck.postman_collection.json
@@ -157,7 +157,9 @@
 			"script": {
 				"type": "text/javascript",
 				"exec": [
-					""
+					"pm.test(\"Status code is 200\", function () {",
+					"  pm.response.to.have.status(200);",
+					"});"
 				]
 			}
 		}

--- a/Transactions.postman_collection.json
+++ b/Transactions.postman_collection.json
@@ -148,7 +148,9 @@
 			"script": {
 				"type": "text/javascript",
 				"exec": [
-					""
+					"pm.test(\"Status code is 200\", function () {",
+					"  pm.response.to.have.status(200);",
+					"});"
 				]
 			}
 		}


### PR DESCRIPTION
Postman gives us the ability to have tests at the Collection level, as well the usual request level.

The commit gives us the ability to assert that every request in the collection will run the following test:
```"pm.test(\"Status code is 200\", function () {",
"  pm.response.to.have.status(200);",
"});"
```

This can be useful if you are running a collection, instead of individual requests, meaning that it will fail at the first test to return !200 instead of running every test that may continue to return 404s.

![Screenshot 2022-02-03 at 15 24 59](https://user-images.githubusercontent.com/98885317/152374026-95bba2a6-c26f-4269-8242-fe6db18bbb93.png)